### PR TITLE
Correct initialization of progress bar

### DIFF
--- a/R/permshap.R
+++ b/R/permshap.R
@@ -143,7 +143,7 @@ permshap.default <- function(object, X, bg_X, pred_fun = stats::predict,
     )
   } else {
     if (verbose && n >= 2L) {
-      pb <- utils::txtProgressBar(1L, n, style = 3)
+      pb <- utils::txtProgressBar(max = n, style = 3)
     }
     res <- vector("list", n)
     for (i in seq_len(n)) {


### PR DESCRIPTION
The progress bar should be initialized with `min = 0`, not `min = 1`.